### PR TITLE
Fix CI-CD tokio not optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "casper-client"
 version = "2.0.0" # when updating, also update 'html_root_url' in lib.rs
-authors = ["Marc Brinkmann <marc@casperlabs.io>", "Fraser Hutchison <fraser@casperlabs.io>", "Zachary Showalter <zach@casperlabs.io>"]
+authors = [
+  "Marc Brinkmann <marc@casperlabs.io>",
+  "Fraser Hutchison <fraser@casperlabs.io>",
+  "Zachary Showalter <zach@casperlabs.io>",
+]
 edition = "2021"
 description = "A client library and binary for interacting with the Casper network"
 documentation = "https://docs.rs/casper-client"
@@ -19,11 +23,10 @@ path = "lib/lib.rs"
 name = "casper-client"
 path = "src/main.rs"
 doc = false
-required-features = ["async-trait", "clap", "clap_complete", "tokio", "std-fs-io"]
+required-features = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 
 [features]
-default = ["async-trait", "clap", "clap_complete", "tokio", "std-fs-io"]
-tokio = ["tokio/macros", "tokio/rt", "tokio/sync"]
+default = ["async-trait", "clap", "clap_complete", "std-fs-io"]
 std-fs-io = ["casper-types/std-fs-io"]
 
 [dependencies]
@@ -33,9 +36,9 @@ base64 = { version = "0.22.1", default-features = false }
 bytes = { version = "1.6.0", default-features = false }
 casper-hashing = "3.0.0"
 casper-types = { version = "4.0.1", features = ["std"] }
-clap = { version = "~4.4", optional = true, features = ["cargo", "deprecated", "wrap_help"] }
+clap = { version = "~4.4", optional = true, features = ["cargo", "deprecated"] }
 clap_complete = { version = "<4.5.0", optional = true }
-flate2 = "1.0.28"
+flate2 = "1.0.30"
 hex-buffer-serde = "0.4.0"
 humantime = "2.1.0"
 itertools = "0.12.0"
@@ -43,13 +46,13 @@ jsonrpc-lite = "0.6.0"
 num-traits = "0.2.15"
 once_cell = "1.18.0"
 rand = "0.8.5"
-reqwest = { version = "0.12.3", features = ["json"] }
+reqwest = { version = "0.12.4", features = ["json"] }
 schemars = "=0.8.5"
 serde = { version = "1.0.193", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.108", features = ["preserve_order"] }
 tar = { version = "0.4.41", default-features = false }
-thiserror = "1.0.50"
-tokio = { version = "1.38.0", features = ["time"] }
+thiserror = "1"
+tokio = { version = "1.38.0", features = ["macros", "rt", "sync", "time"] }
 uint = "0.9.5"
 
 [dev-dependencies]


### PR DESCRIPTION
@moubctez @teon Please merge this PR in yours to make tokio not optional but not a feature.

This passes

```
cargo clippy --all-targets --no-default-features
cargo build --lib --target wasm32-unknown-unknown --no-default-features
```

failing on your PR to pass CI-CD

Thanks
